### PR TITLE
Removed requirements.txt and added extra linting rules

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
     - '**.py'
-    - requirements.txt
     - pyproject.toml
     - tox.ini
   push:
@@ -34,7 +33,7 @@ jobs:
           cache: 'pip'
 
       - name: Install requirements
-        run: pip install -r requirements.txt
+        run: pip install -e .[dev]
 
       - name: Run Tox
         run: tox

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # Scaffold
 Basic python tox, pytest, & coverage project structure
 
+
 ## Installation
 Simply clone, remove the `.git` folder (re-init if you like), and change any `scaffold` references to that of your
 project name. EZPZ
 
+
 ## Usage
-Slap your venv in the root dir, install the requirements, then run `pytest` or `tox` from the root dir to see the
+Slap your venv in the root dir, install the dev requirements with `pip install -e .[dev]`, then run `pytest` or `tox` from the root dir to see the
 results. Tox will run through any specified python versions you put in the `env_list`.
 For added bonus, I've thrown in coverage and markers for slow tests.
 
-Coverage will run everytime you run `tox`, and it will also populate the htmlcov folder with
+Coverage will run everytime you call `tox`, and it will also populate the htmlcov folder with
 [jazz](https://www.youtube.com/watch?v=xuPSIbABYVU) so you can see how lazy you've been with your test coverage.
 Feel free to check the `pyproject.toml` to see adjustable failure rates for coverage.
 Additionally, coverage is aggregated across all the specified python versions,
@@ -23,15 +25,14 @@ If you only care about running the tests (and noting else), you don't have to us
 To run the slow tests, you will have to use the marker: `pytest --runslow`. 
 
 > [!CAUTION]
-> Depending on how you're importing packages, running pytest outside tox might fail. To fix this, you will most likely
-> need to install your current project locally using: `pip install -e .`
+> Depending on how you're importing packages, running pytest outside tox might fail.
+> Relative vs absolute imports and all that nonsense.
 
 
 ## Directory Structure
 ```
 .
 ├── README.md
-├── requirements.txt  # anything required for dev. Intentionally unversioned
 ├── tox.ini
 ├── pyproject.toml  # project and tool settings
 ├── htmlcov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,19 @@ description = "Template repo for python projects"
 readme =  "README.md"
 license = {text = "MIT License"}
 
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "tox",
+]
+lint = [
+    "mypy",
+    "ruff",
+]
+dev = [
+    "scaffold[test,lint]",
+]
+
 
 [tool.coverage.html]
 directory = "htmlcov"
@@ -71,6 +84,18 @@ line-length = 100
 [tool.ruff.format]
 quote-style = "single"
 docstring-code-format = true
+
+[tool.ruff.lint]
+select = [
+    "E4",  # pycodestyle errors 4xx
+    "E7",  # pycodestyle errors 7xx
+    "E9",  # pycodestyle errors 9xx
+    "F",  # pyflakes
+    "I",  # isoert,
+    "N",  # pep8-naming
+    "RUF", # ruff-specific rules
+    "U",  # pyupgrade
+]
 
 
 [tool.setuptools.dynamic]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-pytest
-ruff
-tox

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 # store history of failures per test class name and per index in parametrize (if parametrize used)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,8 @@
-import pytest
-from typing import Dict, Tuple
 
+import pytest
 
 # store history of failures per test class name and per index in parametrize (if parametrize used)
-_test_failed_incremental: Dict[str, Dict[Tuple[int, ...], str]] = {}
+_test_failed_incremental: dict[str, dict[tuple[int, ...], str]] = {}
 
 
 def pytest_addoption(parser):

--- a/tests/functional/test_bar.py
+++ b/tests/functional/test_bar.py
@@ -1,5 +1,6 @@
-from scaffold import bar
 import pytest
+
+from scaffold import bar
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Purpose
- removed `requirements.txt`
- added additional linting rules

## Context
Don't need `requirements.txt` for dev installs anymore. We can use the optional dependencies in `pyproject.toml` instead.