### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-scaffold.ragedriven.dev


### PR DESCRIPTION
## Purpose
- delete CNAME

## Context
A misconfig made GitHub create this in the `master` branch instead of `gh-pages`