### PR TITLE
Add groups to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Purpose
- Add groups to dependabot

## Context
Dependabot was opening a single PR of each dependency. This should change the behaviour to be a single PR.